### PR TITLE
fix: normalize panning speed when zoomed in

### DIFF
--- a/src/components/DiagramPreview.tsx
+++ b/src/components/DiagramPreview.tsx
@@ -418,9 +418,19 @@ export default function DiagramPreview({ code, diagramName, theme, onThemeChange
 
   const handleMouseMove = (e: React.MouseEvent) => {
     if (isDragging) {
-      const newX = e.clientX - dragStart.x;
-      const newY = e.clientY - dragStart.y;
+      // Normalize panning speed based on zoom level to maintain natural feel
+      const panningSpeed = 1 / zoomLevel;
+      const deltaX = (e.clientX - dragStart.x) * panningSpeed;
+      const deltaY = (e.clientY - dragStart.y) * panningSpeed;
+      
+      // Calculate new position based on normalized delta
+      const newX = scrollPosition.x + deltaX;
+      const newY = scrollPosition.y + deltaY;
+      
       setScrollPosition({ x: newX, y: newY });
+      
+      // Update drag start for next movement
+      setDragStart({ x: e.clientX - deltaX / panningSpeed, y: e.clientY - deltaY / panningSpeed });
     }
   };
 
@@ -447,7 +457,9 @@ export default function DiagramPreview({ code, diagramName, theme, onThemeChange
 
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    const panStep = 20; // Pixels to move per key press
+    // Normalize panning step based on zoom level to maintain natural feel
+    const basePanStep = 20; // Base pixels to move per key press
+    const panStep = basePanStep / zoomLevel;
     
     switch (e.key) {
       case 'ArrowUp':
@@ -518,9 +530,19 @@ export default function DiagramPreview({ code, diagramName, theme, onThemeChange
       
       if (e.touches.length === 1 && isDragging) {
         const touch = e.touches[0];
-        const newX = touch.clientX - dragStart.x;
-        const newY = touch.clientY - dragStart.y;
+        // Normalize panning speed based on zoom level to maintain natural feel
+        const panningSpeed = 1 / zoomLevel;
+        const deltaX = (touch.clientX - dragStart.x) * panningSpeed;
+        const deltaY = (touch.clientY - dragStart.y) * panningSpeed;
+        
+        // Calculate new position based on normalized delta
+        const newX = scrollPosition.x + deltaX;
+        const newY = scrollPosition.y + deltaY;
+        
         setScrollPosition({ x: newX, y: newY });
+        
+        // Update drag start for next movement
+        setDragStart({ x: touch.clientX - deltaX / panningSpeed, y: touch.clientY - deltaY / panningSpeed });
       } else if (e.touches.length === 2 && lastTouchDistance > 0) {
         const currentDistance = getTouchDistance(e.touches);
         const scale = currentDistance / lastTouchDistance;


### PR DESCRIPTION
### **User description**
Fixes #1

This PR addresses the issue where panning speed was excessively fast when diagrams were zoomed in.

## Changes

- Fixed panning calculations to normalize speed based on zoom level
- Applied normalization to mouse, touch, and keyboard panning
- Panning now feels natural at any zoom level

## Technical Details

The fix uses inverse zoom level scaling (`1 / zoomLevel`) to ensure panning speed is inversely proportional to zoom level. This maintains consistent visual movement rate regardless of zoom.

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed excessive panning speed when zoomed in

- Normalized panning calculations for mouse, touch, and keyboard

- Applied inverse zoom scaling to maintain natural feel

- Updated drag position tracking for smooth movement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Input"] --> B["Panning Speed Calculation"]
  B --> C["Apply Zoom Normalization"]
  C --> D["1 / zoomLevel scaling"]
  D --> E["Natural Panning Feel"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DiagramPreview.tsx</strong><dd><code>Normalize panning speed based on zoom level</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/DiagramPreview.tsx

<ul><li>Added zoom-based panning speed normalization using <code>1 / zoomLevel</code><br> <li> Updated mouse, touch, and keyboard panning calculations<br> <li> Modified drag position tracking to maintain smooth movement<br> <li> Applied consistent normalization across all panning methods</ul>


</details>


  </td>
  <td><a href="https://github.com/mamertofabian/mermaid-diagram-editor/pull/3/files#diff-a43ef7c8563be1fe3bc3d3a48fada17f1eeb5fd416e9bcf34b9af467141ee4b6">+27/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

